### PR TITLE
Add "after" parameter

### DIFF
--- a/docs/Channel/Messages.md
+++ b/docs/Channel/Messages.md
@@ -52,9 +52,10 @@ $discord = new Discord($email_address, $password);
 $channelId = '<channel_id>';
 $limit = 1;
 $before = '<message_id>';
-$discord->api('channel')->messages()->show($channelId, $limit, $before);
+$after = '<message_id>';
+$discord->api('channel')->messages()->show($channelId, $limit, $before, $after);
 ```
 
 Returns an array of message(s).
 
-> Default limit is 50. Before parameter is optional.
+> Default limit is 50. Before and after parameters is optional.

--- a/src/Api/Channel/Messages.php
+++ b/src/Api/Channel/Messages.php
@@ -66,12 +66,17 @@ class Messages extends AbstractApi
      * @param string|null   $before
      * @return array
      */
-    public function show($channel, $limit = 50, $before = null)
+    public function show($channel, $limit = 50, $before = null, $after = null)
     {
         $params = '?limit=' . $limit;
         if (!is_null($before)) {
             $params .= '&before=' . $before;
         }
+
+        if (!is_null($after)) {
+            $params .= '&after=' . $after;
+        }
+
         return $this->request('get', 'channels/' . $channel . '/messages' . $params);
     }
 }


### PR DESCRIPTION
Adds "after" parameter specified in Discord API, where you can get channel messages that came after specified one 
